### PR TITLE
Build docker image from codebase.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM node:6.9.5-alpine
-
-RUN npm i -g nelson.cli@0.1.4
+FROM node:6.9.5-alpine as builder
+COPY . /usr/src/nelson
 WORKDIR /usr/src/nelson
+RUN npm install -g yarn \
+    && yarn install --pure-lockfile \
+    && yarn make \
+    && npm install -g . \
+    && npm uninstall -g yarn
+
+FROM node:6.9.5-alpine
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 EXPOSE 16600
 EXPOSE 18600
 
-ENTRYPOINT ["nelson"]
+ENTRYPOINT ["/usr/local/bin/nelson"]


### PR DESCRIPTION
I suspect most folk expect to be able to build a Docker image with the
latest code from the Git repo rather than needing to wait for a release
being pushed to NPM.  This achieves that without changing much else.