### PR TITLE
Adds peers list to the API when requesting /peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "blessed-contrib": "^4.8.5",
     "commander": "^2.11.0",
     "external-ip": "^1.3.1",
+    "httpdispatcher": "^2.1.1",
     "ini": "^1.3.5",
     "iota.lib.js": "^0.4.3",
     "ip": "^1.1.5",

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -1,10 +1,24 @@
 const http = require('http');
-
+const HttpDispatcher = require('httpdispatcher');
 
 function createAPI (node) {
-    const server = http.createServer((req, res) => {
+    const dispatcher = new HttpDispatcher();
+    dispatcher.onGet('/', function(req, res) {
         res.writeHead(200, {"Content-Type": "application/json"});
         res.end(JSON.stringify(getNodeStats(node), null, 4));
+    });
+
+    dispatcher.onGet('/peers', function(req, res) {
+        res.writeHead(200, {"Content-Type": "application/json"});
+        res.end(JSON.stringify(node.list.all(), null, 4));
+    });
+
+    const server = http.createServer((request, response) => {
+        try {
+            dispatcher.dispatch(request, response);
+        } catch(err) {
+            console.log(err);
+        }
     });
     server.listen(node.opts.apiPort, node.opts.apiHostname);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1716,6 +1716,12 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+httpdispatcher@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/httpdispatcher/-/httpdispatcher-2.1.1.tgz#1654c470ac48242b194a90fa5eea0aecc9a6bb1e"
+  dependencies:
+    mime-types ">=1.2.5"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -2500,7 +2506,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@>=1.2.5, mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:


### PR DESCRIPTION
Returns a detailed list of all known peers when requesting the `/peers`-API-endpoint. e.g.: `curl http://localhost:18600/peers`