### PR TITLE
Add CMD to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 EXPOSE 16600
 EXPOSE 18600
 
+CMD ["/usr/local/bin/nelson"]
 ENTRYPOINT ["/usr/local/bin/nelson"]


### PR DESCRIPTION
Most popular Docker images that run a service also have a CMD set, for
examples checkout the official Nginx or MySQL images.  I also needed
this when trying to get Nelson deployed alongside IRI using Docker
Compose.