### PR TITLE
Favor peers by ping

### DIFF
--- a/dist/node/node.js
+++ b/dist/node/node.js
@@ -940,15 +940,12 @@ var Node = function (_Base) {
             var _this13 = this;
 
             return new Promise(function (resolve) {
-                var hrTimeStart = function (hrTime) {
-                    return hrTime[0] * 1000000 + hrTime[1] / 1000;
-                }(process.hrtime());
+                var hrTimeStart = process.hrtime();
                 var ws = _this13.sockets.get(peer);
                 var cb = function cb() {
-                    var hrTimeEnd = function (hrTime) {
-                        return hrTime[0] * 1000000 + hrTime[1] / 1000;
-                    }(process.hrtime());
-                    var pingInMs = (hrTimeEnd - hrTimeStart) / 1000;
+                    var pingInMs = function (hrTime) {
+                        return hrTime[0] * 10e2 + hrTime[1] / 10e5;
+                    }(process.hrtime(hrTimeStart));
                     ws.removeListener('pong', cb);
                     _this13.log('Ping for'.green, _this13.formatNode(peer.data.hostname, peer.data.port), (pingInMs + ' ms').green);
                     resolve([peer, pingInMs]);

--- a/dist/node/node.js
+++ b/dist/node/node.js
@@ -533,9 +533,9 @@ var Node = function (_Base) {
                         peer = _ref3[0],
                         ping = _ref3[1];
 
-                    return peer.markConnected(ping).then(function () {
-                        return _this9._ready && _this9.opts.onPeerConnected(peer);
-                    });
+                    return peer.markConnected(ping);
+                }).then(function () {
+                    return _this9._ready && _this9.opts.onPeerConnected(peer);
                 });
             };
 

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -720,11 +720,10 @@ class Node extends Base {
      */
     pingPeer (peer) {
         return new Promise(resolve => {
-            const hrTimeStart = (hrTime => hrTime[0] * 1000000 + hrTime[1] / 1000)(process.hrtime());
+            const hrTimeStart = process.hrtime();
             const ws = this.sockets.get(peer);
             const cb = () => {
-                const hrTimeEnd = (hrTime => hrTime[0] * 1000000 + hrTime[1] / 1000)(process.hrtime());
-                const pingInMs = (hrTimeEnd - hrTimeStart) / 1000;
+                const pingInMs = (hrTime => hrTime[0] * 10e2 + hrTime[1] / 10e5)(process.hrtime(hrTimeStart));
                 ws.removeListener('pong', cb);
                 this.log('Ping for'.green, this.formatNode(peer.data.hostname, peer.data.port), `${pingInMs} ms`.green);
                 resolve([peer, pingInMs]);

--- a/src/node/node.js
+++ b/src/node/node.js
@@ -396,7 +396,7 @@ class Node extends Base {
             }
             this.log('connection established'.green, this.formatNode(peer.data.hostname, peer.data.port));
             this._sendNeighbors(ws);
-            return this.pingPeer(peer).then(([peer, ping]) => peer.markConnected(ping).then(() => this._ready && this.opts.onPeerConnected(peer)));
+            return this.pingPeer(peer).then(([peer, ping]) => peer.markConnected(ping)).then(() => this._ready && this.opts.onPeerConnected(peer));
         };
 
         ws.isAlive = true;


### PR DESCRIPTION
This PR tries to favor peers with low latency, accounting for a quarter of a peer's quality.

Code changes may be needed:
- I'm not happy with the fact that the ping has to be passed via the markConnected function
- I added a log line to display the pings uppon connecting, maybe it should be removed

[Here's the function used to calculate score by ping](http://www.wolframalpha.com/input/?i=plot+1-(log(x)%2Flog(1200))+from+x%3D0+to+1200+y%3D0+to+1&rawformassumption=%7B%22FunClash%22,+%22log%22%7D+-%3E+%7B%22Log10%22%7D) (1200ms being the max timeout value)
![image](https://user-images.githubusercontent.com/6735195/40125637-ad30389e-592b-11e8-8ab8-95cc0aff393f.png)


